### PR TITLE
Updated deps, including nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^2.2.1"
+    "nan": "^2.3.5"
   },
   "devDependencies": {
     "benchmark": "^2.1.0",
     "debug": "^2.2.0",
-    "iconv": "^2.1.11",
-    "libxmljs": "^0.17.1",
-    "ltx": "^2.2.2",
+    "iconv": "^2.2.0",
+    "libxmljs": "^0.18.0",
+    "ltx": "^2.3.0",
     "node-xml": "^1.0.2",
     "sax": "^1.2.1",
     "vows": "^0.8.1"


### PR DESCRIPTION
Fixes issues when running on node v6.

For example, compiling with older nan can result in the following warning:

```
(node) v8::ObjectTemplate::Set() with non-primitive values is deprecated
(node) and will stop working in the next major release.
```