### PR TITLE
Switch Travis CI to Ubuntu Trusty, provides C++11 compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,12 @@
 sudo: false
 
+dist: trusty
+
 language: node_js
 
-env:
-  - CXX="g++-4.8"
-
 node_js:
-  - '0.10'
-  - '0.12'
   - '4'
-  - '5'
-  - 'stable'
-
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
-    - gcc-4.8
+  - '6'
+  - '8'
 
 before_script: npm install -g standard


### PR DESCRIPTION
Also removes unsupported versions of Node as these were failing due to the use of `standard` for linting.

CI tests now take less than half the time to run.