### PR TITLE
Update nan to build on newer node 10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-expat",
-  "version": "2.3.16",
+  "version": "2.3.17",
   "main": "./lib/node-expat",
   "description": "NodeJS binding for fast XML parsing.",
   "keywords": [
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^2.3.5"
+    "nan": "^2.10.0"
   },
   "devDependencies": {
     "benchmark": "^2.1.0",


### PR DESCRIPTION
Build fails on newer node versions, see: nodejs/nan#763 .

```
> node-expat@2.3.16 install /Users/f736trbe/git/tlb/node-xmlexact/node_modules/node-expat
> node-gyp rebuild

  CC(target) Release/obj.target/expat/deps/libexpat/lib/xmlparse.o
  CC(target) Release/obj.target/expat/deps/libexpat/lib/xmltok.o
  CC(target) Release/obj.target/expat/deps/libexpat/lib/xmlrole.o
  LIBTOOL-STATIC Release/libexpat.a
  CXX(target) Release/obj.target/node_expat/node-expat.o
In file included from ../node-expat.cc:1:
In file included from ../../nan/nan.h:192:
../../nan/nan_maybe_43_inl.h:112:15: error: no member named 'ForceSet' in 'v8::Object'
  return obj->ForceSet(isolate->GetCurrentContext(), key, value, attribs);
...
4 warnings and 1 error generated.
make: *** [Release/obj.target/node_expat/node-expat.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:258:23)
gyp ERR! stack     at ChildProcess.emit (events.js:182:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:237:12)
gyp ERR! System Darwin 17.7.0
gyp ERR! command "/usr/local/Cellar/node/10.5.0_1/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/f736trbe/git/tlb/node-xmlexact/node_modules/node-expat
gyp ERR! node -v v10.5.0
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-expat@2.3.16 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the node-expat@2.3.16 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/f736trbe/.npm/_logs/2018-08-06T17_11_05_001Z-debug.log
```