### PR TITLE
add -Wno-cast-function-type to CFLAGS to silence GCC 8 warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,6 +6,7 @@
       'include_dirs': [
         '<!(node -e "require(\'nan\')")'
       ],
+      'cflags': [ "-Wno-cast-function-type" ],
       'dependencies': [
         'deps/libexpat/libexpat.gyp:expat'
       ]


### PR DESCRIPTION
see https://github.com/nodejs/nan/issues/807 and https://github.com/googleapis/cloud-profiler-nodejs/pull/424