### PR TITLE
fix: return `this` from `destroy()`

### DIFF
--- a/lib/node-expat.js
+++ b/lib/node-expat.js
@@ -48,6 +48,7 @@ Parser.prototype.resume = function () {
 Parser.prototype.destroy = function () {
   this.parser.stop()
   this.end()
+  return this
 }
 
 Parser.prototype.destroySoon = function () {


### PR DESCRIPTION
For consistency with Node stream implementations, `destroy()` should likely return `this` - https://nodejs.org/api/stream.html#readabledestroyerror (for example).

**Context**: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57473